### PR TITLE
add call back function support to decide generator scheduling

### DIFF
--- a/workspaces/types/types/environment/environment.d.ts
+++ b/workspaces/types/types/environment/environment.d.ts
@@ -13,6 +13,7 @@ import type {
   BaseGeneratorMeta,
   InstantiateOptions,
   ComposeOptions,
+  SchedulingOptions,
 } from './methods-options.js';
 
 export type EnvironmentConstructor<A extends InputOutputAdapter = InputOutputAdapter> = new (
@@ -149,7 +150,7 @@ export type BaseEnvironment<A = InputOutputAdapter, S extends Store<MemFsEditorF
    */
   getVersion(dependency: string): string | undefined;
 
-  queueGenerator<G extends BaseGenerator = BaseGenerator>(generator: G, queueOptions?: { schedule?: boolean }): Promise<G>;
+  queueGenerator<G extends BaseGenerator = BaseGenerator>(generator: G, queueOptions?: SchedulingOptions): Promise<G>;
 
   rootGenerator<G extends BaseGenerator = BaseGenerator>(): G;
 

--- a/workspaces/types/types/environment/methods-options.d.ts
+++ b/workspaces/types/types/environment/methods-options.d.ts
@@ -81,4 +81,9 @@ export type InstantiateOptions<G extends BaseGenerator = BaseGenerator> = {
   generatorOptions?: Partial<Omit<GetGeneratorOptions<G>, 'env' | 'resolved' | 'namespace'>> | undefined;
 };
 
-export type ComposeOptions<G extends BaseGenerator = BaseGenerator> = InstantiateOptions<G> & { schedule?: boolean };
+export type ComposeOptions<G extends BaseGenerator = BaseGenerator> = InstantiateOptions<G> & SchedulingOptions;
+
+export type SchedulingOptions<G extends BaseGenerator = BaseGenerator> = {
+  /** Schedule can be a simple boolean or a function defined in the generator that returns a boolean */
+  schedule?: boolean | ((generator: G) => boolean);
+};


### PR DESCRIPTION
This PR expands ComposeOptions.schedule option to allow a generator function to decide the scheduling. 

`function: generater: Basegenerator => boolean`

The function receives the generator instance as the parameter and must return a boolean that will decide the scheduling. A **true** return value **schedules** the generator to be run under environment:run loop and a **false** queues the generator tasks **immediately**.



requiredby jhipster/generator-jhipster#25445