### PR TITLE
fix(conflicter): ghost dependency on slash package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16520,6 +16520,7 @@
         "minimatch": "^9.0.0",
         "p-transform": "^4.1.3",
         "pretty-bytes": "^6.1.0",
+        "slash": "^5.1.0",
         "textextensions": "^5.16.0"
       },
       "devDependencies": {
@@ -16528,8 +16529,7 @@
         "@types/diff": "^5.0.3",
         "@types/textextensions": "^2.4.0",
         "@yeoman/adapter": "*",
-        "lodash-es": "^4.17.21",
-        "slash": "^5.1.0"
+        "lodash-es": "^4.17.21"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -16714,7 +16714,6 @@
     },
     "workspaces/conflicter/node_modules/slash": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"

--- a/workspaces/conflicter/package.json
+++ b/workspaces/conflicter/package.json
@@ -44,6 +44,7 @@
     "minimatch": "^9.0.0",
     "p-transform": "^4.1.3",
     "pretty-bytes": "^6.1.0",
+    "slash": "^5.1.0",
     "textextensions": "^5.16.0"
   },
   "devDependencies": {
@@ -52,8 +53,7 @@
     "@types/diff": "^5.0.3",
     "@types/textextensions": "^2.4.0",
     "@yeoman/adapter": "*",
-    "lodash-es": "^4.17.21",
-    "slash": "^5.1.0"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "@yeoman/types": "^1.0.0",


### PR DESCRIPTION
Fixes #7: `slash` is moved from **devDependencies** to **dependencies** since it was being used in [`yo-resolve.ts#L4`](https://github.com/yeoman/yeoman-api/blob/f2744847a843384562adc6bf7f10a1349305c5ea/workspaces/conflicter/src/yo-resolve.ts#L4).

