### PR TITLE
Mark `name` as a required field in `PromptQuestion` type

### DIFF
--- a/workspaces/adapter/types/adapter.d.ts
+++ b/workspaces/adapter/types/adapter.d.ts
@@ -6,7 +6,7 @@ import type { Logger } from './logger.js';
  */
 export type PromptAnswers = InquirerAnswers;
 
-export type PromptQuestion<A extends PromptAnswers = PromptAnswers> = DistinctQuestion<A>;
+export type PromptQuestion<A extends PromptAnswers = PromptAnswers> = DistinctQuestion<A> & { name: string };
 
 /**
  * Provides a set of questions.


### PR DESCRIPTION
Resolves difference in requirements of the `name` field (required in Yeoman, optional in Inquirer) by marking the `name` field as required for Yeoman.

Fixes https://github.com/yeoman/generator/issues/1575