### PR TITLE
feat: export inquirer types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12770,6 +12770,7 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.0.1",
+        "@inquirer/prompts": "^8.0.1",
         "chalk": "^5.2.0",
         "inquirer": "^13.0.1",
         "log-symbols": "^7.0.0",

--- a/workspaces/adapter/package.json
+++ b/workspaces/adapter/package.json
@@ -23,6 +23,9 @@
     },
     "./types": {
       "types": "./types/index.d.ts"
+    },
+    "./inquirer-types": {
+      "types": "./dist/inquirer.d.ts"
     }
   },
   "main": "./dist/index.js",
@@ -41,6 +44,7 @@
   },
   "dependencies": {
     "@inquirer/core": "^11.0.1",
+    "@inquirer/prompts": "^8.0.1",
     "chalk": "^5.2.0",
     "inquirer": "^13.0.1",
     "log-symbols": "^7.0.0",

--- a/workspaces/adapter/src/adapter.ts
+++ b/workspaces/adapter/src/adapter.ts
@@ -1,8 +1,9 @@
 import process from 'node:process';
 import chalk from 'chalk';
+import { Separator } from '@inquirer/core';
 import type { InputOutputAdapter, Logger, PromptAnswers, PromptQuestions } from '../types/index.js';
 import { createLogger } from './log.js';
-import { PromptModule, Separator, createAdapterPromptModule } from './inquirer.js';
+import { PromptModule, createAdapterPromptModule } from './inquirer.js';
 
 export type TerminalAdapterOptions = {
   promptModule?: PromptModule;

--- a/workspaces/adapter/src/inquirer.ts
+++ b/workspaces/adapter/src/inquirer.ts
@@ -1,9 +1,9 @@
-import type expand from '@inquirer/expand';
 import { createPromptModule } from 'inquirer';
+export type * from '@inquirer/prompts';
 
-// Used by Conflicter
-export type ExpandChoices<T> = Parameters<typeof expand<T>>[0]['choices'];
-
+/**
+ * Creates a prompt module with a deprecated `list` prompt aliasing the `select` prompt.
+ */
 export const createAdapterPromptModule: typeof createPromptModule = parameter => {
   const promptModule = createPromptModule(parameter);
   const originalRestoreDefaultPrompts = promptModule.restoreDefaultPrompts;
@@ -24,6 +24,5 @@ export const createAdapterPromptModule: typeof createPromptModule = parameter =>
   promptModule.restoreDefaultPrompts();
   return promptModule;
 };
-export type PromptModule = ReturnType<typeof createPromptModule>;
 
-export { Separator } from '@inquirer/core';
+export type PromptModule = ReturnType<typeof createPromptModule>;


### PR DESCRIPTION

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [x] Enhancement
- [ ] Other, please explain:

## What changes did you make?

Export inquirer types.
Specific inquirer types are not provided, but in some use cases like conflicter that uses expand choices, it needs to import from inquirer directly.
This change allows to import inquirer types directly from adapter for more advanced used case.
<!-- Give an overview -->

## Is there anything you'd like reviewers to focus on?

<!-- Just in case -->